### PR TITLE
単語数をサーバーから自動的に取得する仕組みを実装

### DIFF
--- a/kanoAppVocab.html
+++ b/kanoAppVocab.html
@@ -48,12 +48,20 @@
             //Data
             let data = "";
 
-            //word数
-            let numberOfWords = 1760;
-
             //STARTを押してから解答開始
-            const goolgeAPI_URL = 'https://script.google.com/macros/s/AKfycbwm8a7ju6rgyCDt-0HsT93KgMtrY42r-da72-F4CVpCPPVQF-MYnr_bgZlyjPcwVnZ8cw/exec'
+            const goolgeAPI_URL = 'https://script.google.com/macros/s/AKfycbxEoQdEN8BbANsSEHFdL4VddxCvPblOr0zZWYeILnAsBIkyVEV8sHBpgVpPF_eoiRKA/exec'
             
+            //word数の読み込み
+            let numberOfWords = 0;
+            let request = new XMLHttpRequest();
+            request.open('GET', goolgeAPI_URL+"?choice=lastRow", false);
+            request.send(null);
+            if (request.status == 200){ //正常にウェブサーバーに接続
+                var lastRow = JSON.parse(request.responseText);
+                //console.log(lastRow);
+                numberOfWords = lastRow;
+            }
+
             //問題のスタートとエンドの初期値を設定する
             const startbox = document.getElementById("startNo");
             startbox.value = 1;

--- a/wordmasterAPI.gs
+++ b/wordmasterAPI.gs
@@ -21,6 +21,17 @@ function doGet(e) {
     return response;
   }
 
+  if(e.parameter.choice == "lastRow"){
+    // シートを取得
+    var sheet = getSheet(sheet_name);
+    // シートの最終行を取得
+    var lastRow = sheet.getLastRow();
+
+    response.setMimeType(MimeType.TEXT);
+    response.setContent(lastRow);
+    return response;
+  }
+
   const data = getData();
   response.setMimeType(MimeType.JSON);
   response.setContent(JSON.stringify(data));
@@ -34,6 +45,12 @@ function setValue(analyzedData, cell, start, end) {
   }
 }
 
+function test01() {
+  // シートを取得
+  var sheet = getSheet('dashboard');
+  //　書き込みテスト
+  const range = sheet.getRange('A1:A1').setValue("XXXX!!!!");
+}
 
 function test02(){
   var c = {"startNo":1,


### PR DESCRIPTION
ページを最初に読み込んだ際に、シートに登録されているワード数（lastRow）を自動的に取得できるようにしました。このコードを反映したら、サーバー側のコードをディプロイしてHTML側の52行目の「const goolgeAPI_URL」を適切なものに入れ替えて下さい。